### PR TITLE
Add a timed wait for the main loop

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -305,7 +305,13 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 	MSG msg;
 	while (running)
 	{
-		while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+		// This will become the apps main timer.
+		// Wait for a message with a timeout
+		// If a message arrives, process all pending messages
+		// If timeout occurs, continue to app.update()
+		DWORD result = MsgWaitForMultipleObjects(0, NULL, FALSE, 1, QS_ALLINPUT);
+
+		while (result == WAIT_OBJECT_0 && PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
 		{
 			TranslateMessage(&msg);
 			DispatchMessage(&msg);


### PR DESCRIPTION
Solves #16 

Change the main loop to wait for 1ms in case we don't have new CAN messages. This still allows a 1000Hz update on the app but makes the CPU usage much smaller. (0-1.1% instead of 10%)
<img width="661" height="171" alt="image" src="https://github.com/user-attachments/assets/2eb23885-ef70-4f93-a0f1-9ac8834e7177" />

<img width="650" height="99" alt="image" src="https://github.com/user-attachments/assets/e06df3fd-bce8-45bf-9fd4-a9bace8f3612" />

